### PR TITLE
Workaround for bug in WifiManager

### DIFF
--- a/networkStuff.h
+++ b/networkStuff.h
@@ -68,6 +68,7 @@ void configModeCallback (WiFiManager *myWiFiManager)
 //===========================================================================================
 void startWiFi(const char* hostname, int timeOut) 
 {
+  WiFi.mode(WIFI_STA); // explicitly set mode, esp defaults to STA+AP
   WiFiManager manageWiFi;
   uint32_t lTime = millis();
   String thisAP = String(hostname) + "-" + WiFi.macAddress();


### PR DESCRIPTION
By design ESP defaults into Wifi STA + AP mode, by forcing it to STA mode you will not have an open AP after configuration.